### PR TITLE
fix: apply security, SEO, performance and best practices improvements

### DIFF
--- a/app/(home)/layout.js
+++ b/app/(home)/layout.js
@@ -1,19 +1,28 @@
 import "../globals.css";
 import { Raleway } from "next/font/google";
-import { SpeedInsights } from "@vercel/speed-insights/next";
-import { Analytics } from "@vercel/analytics/react";
+import AnalyticsProviders from "@/components/AnalyticsProviders";
 
 const raleway = Raleway({
   subsets: ["latin"],
   variable: "--font-raleway",
-  weights: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
-  styles: ["normal", "italic"],
+  weight: ["400", "700"],
+  style: ["normal", "italic"],
   display: "swap",
 });
 
 export const metadata = {
   title: "Jhonattas Ferreira | JhoCore",
-  description: "A blog by Jhonattas Ferreira",
+  description:
+    "Personal blog about software engineering, programming and creative coding.",
+  openGraph: {
+    title: "Jhonattas Ferreira | JhoCore",
+    description:
+      "Personal blog about software engineering, programming and creative coding.",
+    url: "https://jhocore.com",
+    siteName: "JhoCore",
+    locale: "en_US",
+    type: "website",
+  },
 };
 
 export default function HomeLayout({ children }) {
@@ -21,8 +30,7 @@ export default function HomeLayout({ children }) {
     <html lang="en" style={{ overflow: "hidden" }}>
       <body className={raleway.className} style={{ overflow: "hidden" }}>
         {children}
-        <SpeedInsights />
-        <Analytics />
+        <AnalyticsProviders />
       </body>
     </html>
   );

--- a/app/(home)/page.js
+++ b/app/(home)/page.js
@@ -159,6 +159,7 @@ export default function Home() {
       </header>
 
       <main className={styles.mainContent}>
+        <h1 className={styles.srOnly}>Jhonattas Ferreira — Software Engineer</h1>
         <section className={styles.title}>
           <span className={jersey_10.className}>
             <div>&gt; Jhonattas;</div>

--- a/app/[lang]/blog/[slug]/page.js
+++ b/app/[lang]/blog/[slug]/page.js
@@ -7,6 +7,8 @@ import {
   FILENAME_END_EN,
   FILENAME_END_PT_BR,
   TITLE_METADATA_POST_SUFIX,
+  BASE_URL,
+  SITE_NAME,
 } from "@/utils/constants";
 import getPostContent from "@/utils/getPostContent";
 
@@ -25,9 +27,18 @@ export async function generateMetadata({ params }) {
   const isEn = lang === EN_LANGUAGE;
   const filenameEnd = isEn ? FILENAME_END_PT_BR : FILENAME_END_EN;
   const { data, oppositeUrl } = getPostContent(slug, filenameEnd);
+  const title = `${data.title}${TITLE_METADATA_POST_SUFIX}`;
   return {
-    title: `${data.title}${TITLE_METADATA_POST_SUFIX}`,
+    title,
     description: data.description,
+    openGraph: {
+      title,
+      description: data.description,
+      url: `${BASE_URL}/${lang}/blog/${slug}`,
+      siteName: SITE_NAME,
+      type: "article",
+      publishedTime: data.date,
+    },
     alternates: {
       languages: {
         en: `/en/blog/${isEn ? slug : oppositeUrl}`,

--- a/app/[lang]/layout.js
+++ b/app/[lang]/layout.js
@@ -1,13 +1,12 @@
 import "../globals.css";
 import { Raleway } from "next/font/google";
-import { SpeedInsights } from "@vercel/speed-insights/next";
-import { Analytics } from "@vercel/analytics/react";
+import AnalyticsProviders from "@/components/AnalyticsProviders";
 
 const raleway = Raleway({
   subsets: ["latin"],
   variable: "--font-raleway",
-  weights: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
-  styles: ["normal", "italic"],
+  weight: ["400", "700"],
+  style: ["normal", "italic"],
   display: "swap",
 });
 
@@ -21,8 +20,7 @@ export default async function LangLayout({ children, params }) {
     <html lang={lang}>
       <body className={raleway.className}>
         {children}
-        <SpeedInsights />
-        <Analytics />
+        <AnalyticsProviders />
       </body>
     </html>
   );

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -4,6 +4,18 @@
   height: 100vh;
 }
 
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .mainContent {
   display: flex;
   flex-direction: column;

--- a/app/robots.js
+++ b/app/robots.js
@@ -1,0 +1,8 @@
+import { BASE_URL } from "@/utils/constants";
+
+export default function robots() {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,0 +1,32 @@
+import getPostMetadata from "@/utils/getPostMetadata";
+import {
+  CONTENT_FOLDER,
+  EN_LANGUAGE,
+  PT_BR_LANGUAGE,
+  BASE_URL,
+} from "@/utils/constants";
+
+export default function sitemap() {
+  const enPosts = getPostMetadata(CONTENT_FOLDER, EN_LANGUAGE);
+  const ptPosts = getPostMetadata(CONTENT_FOLDER, PT_BR_LANGUAGE);
+
+  const staticPages = [
+    { url: BASE_URL, lastModified: new Date(), priority: 1.0 },
+    { url: `${BASE_URL}/en/blog`, lastModified: new Date(), priority: 0.8 },
+    { url: `${BASE_URL}/pt-br/blog`, lastModified: new Date(), priority: 0.8 },
+  ];
+
+  const enPostPages = enPosts.map((post) => ({
+    url: `${BASE_URL}/en/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    priority: 0.64,
+  }));
+
+  const ptPostPages = ptPosts.map((post) => ({
+    url: `${BASE_URL}/pt-br/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    priority: 0.64,
+  }));
+
+  return [...staticPages, ...enPostPages, ...ptPostPages];
+}

--- a/components/AnalyticsProviders/index.js
+++ b/components/AnalyticsProviders/index.js
@@ -1,0 +1,11 @@
+import { SpeedInsights } from "@vercel/speed-insights/next";
+import { Analytics } from "@vercel/analytics/react";
+
+const AnalyticsProviders = () => (
+  <>
+    <SpeedInsights />
+    <Analytics />
+  </>
+);
+
+export default AnalyticsProviders;

--- a/components/IframeP5/index.js
+++ b/components/IframeP5/index.js
@@ -1,7 +1,8 @@
 import styles from "./iframeP5.module.css";
+import { parseP5Metadata } from "./parseP5Metadata";
 
 const IframeP5 = ({ src, metadata }) => {
-  const [title, url] = metadata.split(" $ ");
+  const { title, url } = parseP5Metadata(metadata);
   return (
     <>
       <iframe
@@ -10,6 +11,7 @@ const IframeP5 = ({ src, metadata }) => {
         width="100%"
         height="400px"
         loading="lazy"
+        sandbox="allow-scripts"
         style={{
           border: "none",
         }}

--- a/components/IframeP5/parseP5Metadata.js
+++ b/components/IframeP5/parseP5Metadata.js
@@ -1,0 +1,9 @@
+export function parseP5Metadata(metadata) {
+  const parts = metadata.split(" $ ");
+  if (parts.length !== 2 || !parts[0].trim() || !parts[1].trim()) {
+    throw new Error(
+      `Invalid p5 metadata format: "${metadata}". Expected "title $ url"`
+    );
+  }
+  return { title: parts[0], url: parts[1] };
+}

--- a/components/IframeP5/parseP5Metadata.test.js
+++ b/components/IframeP5/parseP5Metadata.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { parseP5Metadata } from "./parseP5Metadata.js";
+
+describe("parseP5Metadata", () => {
+  it("parses a valid metadata string", () => {
+    const result = parseP5Metadata("Simple Walker $ https://github.com/foo");
+    expect(result.title).toBe("Simple Walker");
+    expect(result.url).toBe("https://github.com/foo");
+  });
+
+  it("throws when the separator is missing", () => {
+    expect(() => parseP5Metadata("Simple Walker")).toThrow(
+      "Invalid p5 metadata format"
+    );
+  });
+
+  it("throws when title is empty", () => {
+    expect(() => parseP5Metadata(" $ https://github.com/foo")).toThrow(
+      "Invalid p5 metadata format"
+    );
+  });
+
+  it("throws when url is empty", () => {
+    expect(() => parseP5Metadata("Simple Walker $ ")).toThrow(
+      "Invalid p5 metadata format"
+    );
+  });
+
+  it("throws when metadata is an empty string", () => {
+    expect(() => parseP5Metadata("")).toThrow("Invalid p5 metadata format");
+  });
+});

--- a/components/LinkTag/index.js
+++ b/components/LinkTag/index.js
@@ -1,10 +1,8 @@
 import Link from "next/link";
+import { isInternalBlogLink } from "./isInternalBlogLink";
 
 const LinkTag = ({ href, children }) => {
-  const isPtBrBlog = "/blog/pt-br/";
-  const isEnBlog = "/blog/en/";
-
-  if (href.startsWith(isPtBrBlog) || href.startsWith(isEnBlog))
+  if (isInternalBlogLink(href))
     return (
       <Link aria-label={children} href={href}>
         {children}

--- a/components/LinkTag/isInternalBlogLink.js
+++ b/components/LinkTag/isInternalBlogLink.js
@@ -1,0 +1,3 @@
+export function isInternalBlogLink(href) {
+  return href.startsWith("/en/blog/") || href.startsWith("/pt-br/blog/");
+}

--- a/components/LinkTag/isInternalBlogLink.test.js
+++ b/components/LinkTag/isInternalBlogLink.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isInternalBlogLink } from "./isInternalBlogLink.js";
+
+describe("isInternalBlogLink", () => {
+  it("returns true for /en/blog/ links", () => {
+    expect(isInternalBlogLink("/en/blog/my-post")).toBe(true);
+  });
+
+  it("returns true for /pt-br/blog/ links", () => {
+    expect(isInternalBlogLink("/pt-br/blog/meu-post")).toBe(true);
+  });
+
+  it("returns false for old-style /blog/en/ links", () => {
+    expect(isInternalBlogLink("/blog/en/my-post")).toBe(false);
+  });
+
+  it("returns false for old-style /blog/pt-br/ links", () => {
+    expect(isInternalBlogLink("/blog/pt-br/meu-post")).toBe(false);
+  });
+
+  it("returns false for external https links", () => {
+    expect(isInternalBlogLink("https://github.com")).toBe(false);
+  });
+
+  it("returns false for external http links", () => {
+    expect(isInternalBlogLink("http://example.com/en/blog/post")).toBe(false);
+  });
+});

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,22 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
+
   async redirects() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-sit",
+  "name": "my-site",
   "version": "1.0.0",
   "description": "Just my site",
   "type": "module",

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -5,14 +5,34 @@ const PT_BR_LANGUAGE = "pt-br";
 // Content folder
 const CONTENT_FOLDER = "content/posts";
 
+// Site
+const BASE_URL = "https://jhocore.com";
+const SITE_NAME = "JhoCore";
+
 // Listing Posts Metadata
 const LISTING_POSTS_METADATA_EN = {
   title: "All Posts | JhoCore",
-  description: "A blog by Jhonattas Ferreira",
+  description: "Articles about software engineering, programming and creative coding.",
+  openGraph: {
+    title: "All Posts | JhoCore",
+    description: "Articles about software engineering, programming and creative coding.",
+    url: `${BASE_URL}/en/blog`,
+    siteName: SITE_NAME,
+    locale: "en_US",
+    type: "website",
+  },
 };
 const LISTING_POSTS_METADATA_PT_BR = {
   title: "Todos os Posts | JhoCore",
-  description: "Um blog de Jhonattas Ferreira",
+  description: "Artigos sobre engenharia de software, programação e creative coding.",
+  openGraph: {
+    title: "Todos os Posts | JhoCore",
+    description: "Artigos sobre engenharia de software, programação e creative coding.",
+    url: `${BASE_URL}/pt-br/blog`,
+    siteName: SITE_NAME,
+    locale: "pt_BR",
+    type: "website",
+  },
 };
 
 // Title Listing Posts
@@ -33,6 +53,8 @@ export {
   EN_LANGUAGE,
   PT_BR_LANGUAGE,
   CONTENT_FOLDER,
+  BASE_URL,
+  SITE_NAME,
   LISTING_POSTS_METADATA_EN,
   LISTING_POSTS_METADATA_PT_BR,
   TITLE_EN,

--- a/utils/getPostContent.js
+++ b/utils/getPostContent.js
@@ -19,6 +19,10 @@ function getPostContent(slug, filenameEnd) {
     }
   }
 
+  if (!filename || !folderName) {
+    throw new Error(`Post not found for slug: "${slug}"`);
+  }
+
   const file = CONTENT_FOLDER + `/${folderName}/${filename}`;
 
   const content = fs.readFileSync(file, ENCODING_UTF8);

--- a/utils/getPostContent.test.js
+++ b/utils/getPostContent.test.js
@@ -55,4 +55,15 @@ describe("getPostContent", () => {
     const result = getPostContent("obs-no-linux", ".en.md");
     expect(result.oppositeUrl).toBe("obs-on-linux");
   });
+
+  it("throws when slug is not found in any folder", () => {
+    fs.readdirSync.mockImplementation((path) => {
+      if (path === "content/posts/") return ["obs-on-linux"];
+      if (path === "content/posts/obs-on-linux/") return ["other-file.en.md"];
+      return [];
+    });
+    expect(() => getPostContent("nonexistent-slug", ".pt-br.md")).toThrow(
+      'Post not found for slug: "nonexistent-slug"'
+    );
+  });
 });

--- a/utils/getPostMetadata.js
+++ b/utils/getPostMetadata.js
@@ -11,6 +11,8 @@ export default function getPostMetadata(basePath, language) {
 
     const filename = files.find((file) => file.includes(`.${language}.md`));
 
+    if (!filename) return null;
+
     const fileContent = fs.readFileSync(
       `${basePath}/${postFolder}/${filename}`,
       ENCODING_UTF8
@@ -27,5 +29,5 @@ export default function getPostMetadata(basePath, language) {
     };
   });
 
-  return posts.sort((a, b) => new Date(b.date) - new Date(a.date));
+  return posts.filter(Boolean).sort((a, b) => new Date(b.date) - new Date(a.date));
 }

--- a/utils/getPostMetadata.test.js
+++ b/utils/getPostMetadata.test.js
@@ -61,4 +61,16 @@ describe("getPostMetadata", () => {
     expect(post.gif).toBe("/post-one.gif");
     expect(post.altTextGif).toBe("alt one");
   });
+
+  it("skips posts that have no file for the requested language", () => {
+    fs.readdirSync.mockImplementation((path) => {
+      if (path === "content/posts/") return ["post-one", "pt-only-post"];
+      if (path === "content/posts/post-one/") return ["post-one.en.md"];
+      if (path === "content/posts/pt-only-post/") return ["pt-only-post.pt-br.md"];
+      return [];
+    });
+    const result = getPostMetadata("content/posts", "en");
+    expect(result.length).toBe(1);
+    expect(result[0].slug).toBe("post-one");
+  });
 });


### PR DESCRIPTION
Security:
- add X-Frame-Options, X-Content-Type-Options, Referrer-Policy and Permissions-Policy headers to next.config.js
- add sandbox="allow-scripts" to p5.js iframes
- fix LinkTag internal link detection to use current URL structure (/en/blog/, /pt-br/blog/) instead of old redirected paths

SEO:
- add Open Graph metadata to home, blog listing and post pages
- differentiate page descriptions (home vs listing vs post)
- replace static sitemap.xml with auto-generated app/sitemap.js
- add app/robots.js served automatically by Next.js
- add visually hidden h1 to home page for screen readers

Performance:
- reduce Raleway font from 9 weights to only 400 and 700

Bug fixes (with unit tests):
- getPostContent: throw descriptive error when slug is not found
- getPostMetadata: skip posts missing a file for the requested language
- extract isInternalBlogLink as pure function with 6 unit tests
- extract parseP5Metadata as pure function with 5 unit tests and validation for malformed metadata strings

Refactoring:
- extract AnalyticsProviders component shared between both root layouts
- fix package.json name typo (my-sit -> my-site)