### PR TITLE
test: add Playwright E2E tests and fix legacy internal link detection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,55 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test
+        env:
+          CI: true
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .next
+playwright-report
+test-results

--- a/components/LinkTag/isInternalBlogLink.test.ts
+++ b/components/LinkTag/isInternalBlogLink.test.ts
@@ -10,12 +10,12 @@ describe("isInternalBlogLink", () => {
     expect(isInternalBlogLink("/pt-br/blog/meu-post")).toBe(true);
   });
 
-  it("returns false for old-style /blog/en/ links", () => {
-    expect(isInternalBlogLink("/blog/en/my-post")).toBe(false);
+  it("returns true for legacy /blog/en/ links", () => {
+    expect(isInternalBlogLink("/blog/en/my-post")).toBe(true);
   });
 
-  it("returns false for old-style /blog/pt-br/ links", () => {
-    expect(isInternalBlogLink("/blog/pt-br/meu-post")).toBe(false);
+  it("returns true for legacy /blog/pt-br/ links", () => {
+    expect(isInternalBlogLink("/blog/pt-br/meu-post")).toBe(true);
   });
 
   it("returns false for external https links", () => {

--- a/components/LinkTag/isInternalBlogLink.ts
+++ b/components/LinkTag/isInternalBlogLink.ts
@@ -1,3 +1,8 @@
 export function isInternalBlogLink(href: string): boolean {
-  return href.startsWith("/en/blog/") || href.startsWith("/pt-br/blog/");
+  return (
+    href.startsWith("/en/blog/") ||
+    href.startsWith("/pt-br/blog/") ||
+    href.startsWith("/blog/en/") ||
+    href.startsWith("/blog/pt-br/")
+  );
 }

--- a/e2e/blog-listing.spec.ts
+++ b/e2e/blog-listing.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Blog listing", () => {
+  test("EN listing renders posts", async ({ page }) => {
+    await page.goto("/en/blog");
+    const articles = page.locator("article");
+    await expect(articles.first()).toBeVisible();
+    await expect(articles).toHaveCount(9);
+  });
+
+  test("PT-BR listing renders posts", async ({ page }) => {
+    await page.goto("/pt-br/blog");
+    const articles = page.locator("article");
+    await expect(articles.first()).toBeVisible();
+    await expect(articles).toHaveCount(9);
+  });
+
+  test("EN listing language switch points to PT-BR", async ({ page }) => {
+    await page.goto("/en/blog");
+    const langLink = page.getByRole("link", {
+      name: "Change to Brazilian Portuguese",
+    });
+    await expect(langLink).toHaveAttribute("href", "/pt-br/blog");
+  });
+
+  test("PT-BR listing language switch points to EN", async ({ page }) => {
+    await page.goto("/pt-br/blog");
+    const langLink = page.getByRole("link", { name: "Change to English" });
+    await expect(langLink).toHaveAttribute("href", "/en/blog");
+  });
+
+  test("post card links use correct URL format", async ({ page }) => {
+    await page.goto("/en/blog");
+    const firstArticleLink = page.locator("article a").first();
+    await expect(firstArticleLink).toHaveAttribute("href", /^\/en\/blog\/.+/);
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Home page", () => {
+  test("loads successfully", async ({ page }) => {
+    const response = await page.goto("/");
+    expect(response?.status()).toBe(200);
+  });
+
+  test("navigates to EN blog via nav link", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("nav").getByRole("link", { name: "Blog" }).click();
+    await expect(page).toHaveURL("/en/blog");
+  });
+});

--- a/e2e/post.spec.ts
+++ b/e2e/post.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+
+const EN_POST_URL = "/en/blog/vectors-everywhere";
+const PT_BR_POST_URL = "/pt-br/blog/vetores-em-todos-os-lugares";
+
+test.describe("Post page — vectors-everywhere", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(EN_POST_URL);
+  });
+
+  test("cover GIF is rendered", async ({ page }) => {
+    const coverImage = page.getByAltText(
+      "A vaporwave-style GIF with a camera moving through a checkered road under rain, palm trees on the sides, mountains in the background, and a large moon in the sky."
+    );
+    await expect(coverImage).toBeVisible();
+    await expect(coverImage).toHaveAttribute("src", /vector\.webp/);
+  });
+
+  test("static images in content are rendered", async ({ page }) => {
+    const staticImage = page.getByAltText(
+      "An image containing an arrow representing a vector. The arrow is black, and the background is white."
+    );
+    await expect(staticImage).toBeVisible();
+    await expect(staticImage).toHaveAttribute("src", /vectorEuclid\.png/);
+  });
+
+  test("three p5.js iframes are rendered", async ({ page }) => {
+    const iframes = page.locator(
+      'iframe[title^="p5.js iframe sketch:"]'
+    );
+    await expect(iframes).toHaveCount(3);
+    for (const iframe of await iframes.all()) {
+      await expect(iframe).toBeVisible();
+    }
+  });
+
+  test("p5.js iframes point to the correct sketch paths", async ({ page }) => {
+    const expectedSrcs = [
+      "/vectors-everywhere/p5Examples/bee/index.html",
+      "/vectors-everywhere/p5Examples/ballWithVector/index.html",
+      "/vectors-everywhere/p5Examples/ballFollowMouse/index.html",
+    ];
+    for (const src of expectedSrcs) {
+      await expect(page.locator(`iframe[src="${src}"]`)).toBeVisible();
+    }
+  });
+
+  test("internal link navigates to the linked post", async ({ page }) => {
+    const internalLink = page
+      .getByRole("link", { name: "previous chapter's post" })
+      .first();
+    await internalLink.click();
+    await expect(page).toHaveURL("/en/blog/a-random-walker");
+  });
+
+  test("legacy blog URL redirects to new URL structure", async ({ page }) => {
+    await page.goto("/blog/en/a-random-walker");
+    await expect(page).toHaveURL("/en/blog/a-random-walker");
+  });
+
+  test("language switch navigates to PT-BR version", async ({ page }) => {
+    const langLink = page.getByRole("link", {
+      name: "Change to Brazilian Portuguese",
+    });
+    await expect(langLink).toHaveAttribute(
+      "href",
+      `/${PT_BR_POST_URL.slice(1)}`
+    );
+    await langLink.click();
+    await expect(page).toHaveURL(PT_BR_POST_URL);
+  });
+});

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-syntax-highlighter": "^16.1.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^25.6.2",
@@ -1339,6 +1340,22 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3853,6 +3870,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "dev": "next dev",
-    "build": "next build"
+    "build": "next build",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "author": "",
   "license": "ISC",
@@ -27,6 +29,7 @@
     "postcss": ">=8.5.10"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^25.6.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run build && npx next start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -6,6 +6,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
+    exclude: ["**/node_modules/**", "**/e2e/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- Add Playwright E2E tests for home, blog listing, and post pages
- Use vectors-everywhere as fixture (covers GIF, static images, p5.js iframes, internal links, language switch)
- Fix isInternalBlogLink to recognize legacy /blog/en/ and /blog/pt-br/ URLs so they open in the same tab instead of _blank
- Add GitHub Actions workflow running unit and E2E tests in parallel
- Exclude e2e/ from Vitest to avoid conflicts