### PR TITLE
perf: optimize image delivery and reduce CLS for better Lighthouse score

### DIFF
--- a/__mocks__/next/image.tsx
+++ b/__mocks__/next/image.tsx
@@ -1,6 +1,13 @@
-const NextImage = (props: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean; unoptimized?: boolean; sizes?: string; fill?: boolean }) => {
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
+  priority?: boolean;
+  unoptimized?: boolean;
+  sizes?: string;
+  fill?: boolean;
+};
+
+const NextImage = ({ unoptimized, priority, sizes, fill, ...props }: Props) => {
   // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
-  return <img {...props} />;
+  return <img {...props} data-unoptimized={unoptimized ? "true" : undefined} />;
 };
 
 export default NextImage;

--- a/components/Image/index.test.tsx
+++ b/components/Image/index.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import ImageBlock from "./index";
+
+vi.mock("next/image");
 
 describe("ImageBlock", () => {
   describe("when src contains p5Examples", () => {
@@ -49,6 +51,23 @@ describe("ImageBlock", () => {
     it("uses eager loading for webp", () => {
       render(<ImageBlock src="/my-post/cover.webp" alt="animated cover" />);
       expect(screen.getByRole("img")).toHaveAttribute("loading", "eager");
+    });
+  });
+
+  describe("unoptimized attribute", () => {
+    it("gif is unoptimized to preserve animation", () => {
+      render(<ImageBlock src="/my-post/cover.gif" alt="animated cover" />);
+      expect(screen.getByRole("img")).toHaveAttribute("data-unoptimized", "true");
+    });
+
+    it("webp is not unoptimized so Next.js can compress it", () => {
+      render(<ImageBlock src="/my-post/cover.webp" alt="cover" />);
+      expect(screen.getByRole("img")).not.toHaveAttribute("data-unoptimized");
+    });
+
+    it("png is not unoptimized so Next.js can compress it", () => {
+      render(<ImageBlock src="/my-post/cover.png" alt="cover" />);
+      expect(screen.getByRole("img")).not.toHaveAttribute("data-unoptimized");
     });
   });
 });

--- a/components/Image/index.tsx
+++ b/components/Image/index.tsx
@@ -11,8 +11,8 @@ const ImageBlock = ({ alt = "", src }: Props) => {
     return <IframeP5 src={srcStr} metadata={alt} />;
   }
 
-  const isGifOrWebp =
-    srcStr.toLowerCase().endsWith(".gif") || srcStr.toLowerCase().endsWith(".webp");
+  const isGif = srcStr.toLowerCase().endsWith(".gif");
+  const isGifOrWebp = isGif || srcStr.toLowerCase().endsWith(".webp");
 
   return (
     <NextImage
@@ -21,7 +21,7 @@ const ImageBlock = ({ alt = "", src }: Props) => {
       width={0}
       height={0}
       sizes="100vw"
-      unoptimized
+      unoptimized={isGif}
       priority={isGifOrWebp}
       loading={isGifOrWebp ? "eager" : "lazy"}
       style={{

--- a/components/PostFrontmatter/PostFrontmatter.module.css
+++ b/components/PostFrontmatter/PostFrontmatter.module.css
@@ -47,6 +47,7 @@
 
 .gifSection {
   margin-top: 1.5rem;
+  min-height: 300px;
 }
 
 .post {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
- Remove `unoptimized` for webp/png so Next.js compression and fetchpriority work
- Keep `unoptimized` only for GIFs to preserve animation
- Add min-height to gifSection to reserve space and prevent layout shift
- Update next/image mock to expose unoptimized prop via data-unoptimized
- Add explicit vi.mock("next/image") and new unit tests for unoptimized behavior