### PR TITLE
test: add missing coverage for hook, components, utils, and e2e layers

### DIFF
--- a/app/(home)/useHomeAnimation.test.ts
+++ b/app/(home)/useHomeAnimation.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useHomeAnimation from "./useHomeAnimation";
+
+const mockRect = {
+  top: 100,
+  left: 200,
+  width: 30,
+  height: 30,
+  right: 230,
+  bottom: 130,
+} as DOMRect;
+
+const mockNavRect = {
+  top: 50,
+  left: 100,
+  right: 900,
+  bottom: 70,
+  width: 800,
+  height: 20,
+} as DOMRect;
+
+const makeRectangleRef = (rect = mockRect) => ({
+  current: { getBoundingClientRect: () => rect } as unknown as HTMLDivElement,
+});
+
+const makeNavRef = (rect = mockNavRect) => ({
+  current: { getBoundingClientRect: () => rect } as unknown as HTMLDivElement,
+});
+
+const nullRef = { current: null };
+
+function mockWindow({
+  innerWidth = 1200,
+  innerHeight = 800,
+  reducedMotion = false,
+} = {}) {
+  Object.defineProperty(window, "innerWidth", {
+    value: innerWidth,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    value: innerHeight,
+    writable: true,
+    configurable: true,
+  });
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: reducedMotion && query.includes("reduce"),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockWindow();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("useHomeAnimation", () => {
+  describe("initial state", () => {
+    it("starts with idle phase", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      expect(result.current.phase).toBe("idle");
+    });
+
+    it("starts with balls hidden", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      expect(result.current.ballsVisible).toBe(false);
+    });
+
+    it("starts with balls not jumping or trembling", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      expect(result.current.ballsJumping).toBe(false);
+      expect(result.current.ballsTrembling).toBe(false);
+    });
+
+    it("starts with full ball opacity", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      expect(result.current.ballsOpacity).toBe(1);
+    });
+
+    it("exposes the BALLS config and BALL_SIZE", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      expect(result.current.balls).toHaveLength(4);
+      expect(result.current.ballSize).toBeGreaterThan(0);
+    });
+  });
+
+  describe("accessibility guards", () => {
+    it("does not start animation when prefers-reduced-motion is set", () => {
+      mockWindow({ reducedMotion: true });
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(result.current.phase).toBe("idle");
+    });
+
+    it("does not start animation on viewports narrower than 962px", () => {
+      mockWindow({ innerWidth: 961 });
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(result.current.phase).toBe("idle");
+    });
+  });
+
+  describe("animation phases", () => {
+    it("transitions to falling phase after the initial 2000ms delay", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(result.current.phase).toBe("falling");
+    });
+
+    it("does not crash when rectangleRef is null", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(nullRef, makeNavRef())
+      );
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(result.current.phase).toBe("falling");
+    });
+
+    it("shows balls after BALLS_APPEAR delay when phase is resting", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      act(() => {
+        result.current.setPhase("resting");
+      });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(result.current.ballsVisible).toBe(true);
+    });
+
+    it("transitions to approaching phase after BALLS_APPROACH delay", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      act(() => {
+        result.current.setPhase("resting");
+      });
+      act(() => {
+        vi.advanceTimersByTime(550);
+      });
+      expect(result.current.phase).toBe("approaching");
+    });
+
+    it("sets ballsJumping true after BALLS_JUMP delay", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      act(() => {
+        result.current.setPhase("resting");
+      });
+      act(() => {
+        vi.advanceTimersByTime(3750);
+      });
+      expect(result.current.ballsJumping).toBe(true);
+    });
+
+    it("sets ballsTrembling true after BALLS_TREMBLE delay", () => {
+      const { result } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      act(() => {
+        result.current.setPhase("resting");
+      });
+      act(() => {
+        vi.advanceTimersByTime(8900);
+      });
+      expect(result.current.ballsTrembling).toBe(true);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("cancels pending timers on unmount", () => {
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+      const { unmount } = renderHook(() =>
+        useHomeAnimation(makeRectangleRef(), makeNavRef())
+      );
+      unmount();
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+      clearTimeoutSpy.mockRestore();
+    });
+  });
+});

--- a/app/RootShell.test.tsx
+++ b/app/RootShell.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/components/AnalyticsProviders", () => ({
+  default: () => null,
+}));
+
+vi.mock("./fonts", () => ({
+  raleway: { className: "raleway-mock" },
+}));
+
+import RootShell from "./RootShell";
+
+describe("RootShell", () => {
+  it("renders children", () => {
+    render(
+      <RootShell lang="en">
+        <main>Page content</main>
+      </RootShell>
+    );
+    expect(screen.getByText("Page content")).toBeInTheDocument();
+  });
+
+  it("renders the skip link with the correct href", () => {
+    render(<RootShell lang="en"><div /></RootShell>);
+    const skipLink = screen.getByText("Skip to main content");
+    expect(skipLink).toHaveAttribute("href", "#main-content");
+  });
+
+  it("renders multiple children", () => {
+    render(
+      <RootShell lang="en">
+        <nav>Nav</nav>
+        <main>Main</main>
+      </RootShell>
+    );
+    expect(screen.getByText("Nav")).toBeInTheDocument();
+    expect(screen.getByText("Main")).toBeInTheDocument();
+  });
+});

--- a/app/[lang]/blog/[slug]/page.tsx
+++ b/app/[lang]/blog/[slug]/page.tsx
@@ -13,6 +13,8 @@ import getOppositeFilenameSuffix from "@/utils/post/getOppositeFilenameSuffix";
 
 type Props = { params: Promise<{ lang: string; slug: string }> };
 
+export const dynamicParams = false;
+
 export const generateStaticParams = async () => {
   const enPosts = getPostMetadata(CONTENT_FOLDER, EN_LANGUAGE);
   const ptPosts = getPostMetadata(CONTENT_FOLDER, PT_BR_LANGUAGE);

--- a/app/robots.test.ts
+++ b/app/robots.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import robots from "./robots";
+import { BASE_URL } from "@/utils/constants";
+
+describe("robots", () => {
+  it("allows all user agents", () => {
+    expect(robots().rules.userAgent).toBe("*");
+  });
+
+  it("allows access to all paths", () => {
+    expect(robots().rules.allow).toBe("/");
+  });
+
+  it("points to the correct sitemap URL", () => {
+    expect(robots().sitemap).toBe(`${BASE_URL}/sitemap.xml`);
+  });
+});

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/utils/post/getPostMetadata");
+
+import getPostMetadata from "@/utils/post/getPostMetadata";
+import sitemap from "./sitemap";
+import { BASE_URL, EN_LANGUAGE, PT_BR_LANGUAGE } from "@/utils/constants";
+import type { PostMetadata } from "@/types";
+
+const makePost = (slug: string, date: string): PostMetadata => ({
+  slug,
+  date,
+  title: `Post ${slug}`,
+  gif: "/cover.gif",
+  altTextGif: "cover",
+  description: "desc",
+});
+
+const enPosts = [makePost("post-one", "2024-01-01"), makePost("post-two", "2024-06-15")];
+const ptPosts = [makePost("post-um", "2024-01-01"), makePost("post-dois", "2024-06-15")];
+
+beforeEach(() => {
+  vi.mocked(getPostMetadata).mockImplementation((_, lang) =>
+    lang === EN_LANGUAGE ? enPosts : ptPosts
+  );
+});
+
+describe("sitemap", () => {
+  it("includes the three static pages", () => {
+    const entries = sitemap();
+    const urls = entries.map((e) => e.url);
+    expect(urls).toContain(BASE_URL);
+    expect(urls).toContain(`${BASE_URL}/en/blog`);
+    expect(urls).toContain(`${BASE_URL}/pt-br/blog`);
+  });
+
+  it("assigns correct priorities to static pages", () => {
+    const entries = sitemap();
+    const home = entries.find((e) => e.url === BASE_URL);
+    const enBlog = entries.find((e) => e.url === `${BASE_URL}/en/blog`);
+    const ptBlog = entries.find((e) => e.url === `${BASE_URL}/pt-br/blog`);
+    expect(home?.priority).toBe(1.0);
+    expect(enBlog?.priority).toBe(0.8);
+    expect(ptBlog?.priority).toBe(0.8);
+  });
+
+  it("generates correct EN post URLs", () => {
+    const entries = sitemap();
+    expect(entries.find((e) => e.url === `${BASE_URL}/en/blog/post-one`)).toBeDefined();
+    expect(entries.find((e) => e.url === `${BASE_URL}/en/blog/post-two`)).toBeDefined();
+  });
+
+  it("generates correct PT-BR post URLs", () => {
+    const entries = sitemap();
+    expect(entries.find((e) => e.url === `${BASE_URL}/pt-br/blog/post-um`)).toBeDefined();
+    expect(entries.find((e) => e.url === `${BASE_URL}/pt-br/blog/post-dois`)).toBeDefined();
+  });
+
+  it("sets post lastModified as a Date derived from post.date", () => {
+    const entries = sitemap();
+    const postEntry = entries.find((e) => e.url === `${BASE_URL}/en/blog/post-one`);
+    expect(postEntry?.lastModified).toBeInstanceOf(Date);
+    expect((postEntry?.lastModified as Date).getUTCFullYear()).toBe(2024);
+  });
+
+  it("assigns priority 0.64 to all post entries", () => {
+    const entries = sitemap();
+    const postEntries = entries.filter((e) => e.url.includes("/blog/post-"));
+    expect(postEntries.every((e) => e.priority === 0.64)).toBe(true);
+  });
+
+  it("total entries equals 3 static plus all posts from both languages", () => {
+    const entries = sitemap();
+    expect(entries).toHaveLength(3 + enPosts.length + ptPosts.length);
+  });
+});

--- a/components/LayoutPost/index.test.tsx
+++ b/components/LayoutPost/index.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { Lang, PostFrontmatter } from "@/types";
+
+vi.mock("@/components/PostFrontmatter", () => ({
+  default: vi.fn(({ children }: { children: React.ReactNode }) => (
+    <div data-testid="post-frontmatter">{children}</div>
+  )),
+}));
+
+vi.mock("@/components/Comments", () => ({
+  default: vi.fn(() => <div data-testid="comments" />),
+}));
+
+vi.mock("react-markdown", () => ({
+  default: vi.fn(() => <div data-testid="markdown" />),
+}));
+
+vi.mock("@/utils/post/getReadingTime", () => ({
+  default: vi.fn(() => 5),
+}));
+
+import PostFrontmatter from "@/components/PostFrontmatter";
+import Comments from "@/components/Comments";
+import getReadingTime from "@/utils/post/getReadingTime";
+import LayoutPost from "./index";
+
+const mockFrontmatter: PostFrontmatter = {
+  title: "Test Post",
+  date: "2024-03-10",
+  gif: "/test/cover.gif",
+  altTextGif: "A test gif",
+  description: "A short description",
+};
+
+const defaultProps = {
+  content: "# Hello world",
+  frontmatter: mockFrontmatter,
+  language: "en" as Lang,
+  oppositeUrl: "post-de-teste",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const getLastPostFrontmatterProps = () =>
+  vi.mocked(PostFrontmatter).mock.calls.at(-1)![0];
+
+const getLastCommentsProps = () =>
+  vi.mocked(Comments).mock.calls.at(-1)![0];
+
+describe("LayoutPost", () => {
+  it("renders without crashing", () => {
+    expect(() => render(<LayoutPost {...defaultProps} />)).not.toThrow();
+  });
+
+  it("calls getReadingTime with the post content", () => {
+    render(<LayoutPost {...defaultProps} />);
+    expect(vi.mocked(getReadingTime)).toHaveBeenCalledWith(defaultProps.content);
+  });
+
+  it("passes readingTime from getReadingTime to PostFrontmatter", () => {
+    vi.mocked(getReadingTime).mockReturnValue(8);
+    render(<LayoutPost {...defaultProps} />);
+    expect(getLastPostFrontmatterProps().readingTime).toBe(8);
+  });
+
+  it("passes all frontmatter fields to PostFrontmatter", () => {
+    render(<LayoutPost {...defaultProps} />);
+    const props = getLastPostFrontmatterProps();
+    expect(props.title).toBe(mockFrontmatter.title);
+    expect(props.date).toBe(mockFrontmatter.date);
+    expect(props.gif).toBe(mockFrontmatter.gif);
+    expect(props.altTextGif).toBe(mockFrontmatter.altTextGif);
+    expect(props.description).toBe(mockFrontmatter.description);
+  });
+
+  it("passes language and oppositeUrl to PostFrontmatter", () => {
+    render(<LayoutPost {...defaultProps} />);
+    const props = getLastPostFrontmatterProps();
+    expect(props.language).toBe("en");
+    expect(props.oppositeUrl).toBe("post-de-teste");
+  });
+
+  it("passes language to Comments as lang prop", () => {
+    render(<LayoutPost {...defaultProps} />);
+    expect(getLastCommentsProps().lang).toBe("en");
+  });
+
+  it("passes pt-br language correctly to Comments", () => {
+    render(<LayoutPost {...defaultProps} language="pt-br" />);
+    expect(getLastCommentsProps().lang).toBe("pt-br");
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -11,4 +11,20 @@ test.describe("Home page", () => {
     await page.locator("nav").getByRole("link", { name: "Blog" }).click();
     await expect(page).toHaveURL("/en/blog");
   });
+
+  test("html element has lang=en", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+  });
+
+  test("skip link is present with correct href", async ({ page }) => {
+    await page.goto("/");
+    const skipLink = page.getByText("Skip to main content");
+    await expect(skipLink).toHaveAttribute("href", "#main-content");
+  });
+
+  test("renders the main heading with Jhonattas", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Jhonattas");
+  });
 });

--- a/e2e/not-found.spec.ts
+++ b/e2e/not-found.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("404 — not found", () => {
+  test("unknown URL returns 404", async ({ page }) => {
+    const response = await page.goto("/this-page-does-not-exist");
+    expect(response?.status()).toBe(404);
+  });
+
+  test("unknown blog post returns 404", async ({ page }) => {
+    const response = await page.goto("/en/blog/post-that-does-not-exist");
+    expect(response?.status()).toBe(404);
+  });
+});

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+const EN_POST_URL = "/en/blog/a-random-walker";
+const EN_BLOG_URL = "/en/blog";
+const PT_BR_BLOG_URL = "/pt-br/blog";
+
+test.describe("SEO meta tags", () => {
+  test("EN post has a non-empty og:title", async ({ page }) => {
+    await page.goto(EN_POST_URL);
+    const ogTitle = page.locator('meta[property="og:title"]');
+    const content = await ogTitle.getAttribute("content");
+    expect(content).toBeTruthy();
+    expect(content!.length).toBeGreaterThan(0);
+  });
+
+  test("EN post has a non-empty meta description", async ({ page }) => {
+    await page.goto(EN_POST_URL);
+    const metaDesc = page.locator('meta[name="description"]');
+    const content = await metaDesc.getAttribute("content");
+    expect(content).toBeTruthy();
+    expect(content!.length).toBeGreaterThan(0);
+  });
+
+  test("EN blog listing has hreflang pointing to PT-BR", async ({ page }) => {
+    await page.goto(EN_BLOG_URL);
+    const hreflangPtBr = page.locator('link[rel="alternate"][hreflang="pt-BR"]');
+    const href = await hreflangPtBr.getAttribute("href");
+    expect(href).toContain("/pt-br/blog");
+  });
+
+  test("PT-BR blog listing has hreflang pointing to EN", async ({ page }) => {
+    await page.goto(PT_BR_BLOG_URL);
+    const hreflangEn = page.locator('link[rel="alternate"][hreflang="en"]');
+    const href = await hreflangEn.getAttribute("href");
+    expect(href).toContain("/en/blog");
+  });
+});

--- a/e2e/sitemap-robots.spec.ts
+++ b/e2e/sitemap-robots.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Sitemap and robots", () => {
+  test("GET /sitemap.xml returns 200", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    expect(response.status()).toBe(200);
+  });
+
+  test("sitemap contains the site base URL", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    const body = await response.text();
+    expect(body).toContain("https://jhocore.com");
+  });
+
+  test("sitemap contains EN blog post URLs", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    const body = await response.text();
+    expect(body).toContain("/en/blog/");
+  });
+
+  test("sitemap contains PT-BR blog post URLs", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    const body = await response.text();
+    expect(body).toContain("/pt-br/blog/");
+  });
+
+  test("GET /robots.txt returns 200", async ({ request }) => {
+    const response = await request.get("/robots.txt");
+    expect(response.status()).toBe(200);
+  });
+
+  test("robots.txt references the sitemap", async ({ request }) => {
+    const response = await request.get("/robots.txt");
+    const body = await response.text();
+    expect(body).toContain("sitemap.xml");
+  });
+});

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Add unit tests for useHomeAnimation (phases, accessibility guards, cleanup), LayoutPost (prop propagation), sitemap and robots functions. Add E2E tests for sitemap.xml, robots.txt, home lang/skip-link, SEO meta tags, and 404. Also fix dynamicParams=false on the post page so unknown slugs return 404.